### PR TITLE
Update Windows activation to use VS2019

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: rust_{{ cross_target_platform }}
@@ -33,7 +33,7 @@ outputs:
         - clang_{{ cross_target_platform }}
 {% elif cross_target_platform.startswith("win") %}
         - clang_{{ cross_target_platform }}    # [unix]
-        - vs2017_{{ cross_target_platform }}   # [win]
+        - vs2019_{{ cross_target_platform }}   # [win]
 {% endif %}
         - ld64_{{ target_platform }}  # [osx]
     test:


### PR DESCRIPTION
Inspired by conda-forge/cryptography-feedstock#104 and my reading of conda-forge/conda-forge.github.io#1732, I think the Rust activation packages on Windows need updating to stay in sync with the VS2019 bump.

xref conda-forge/conda-forge-pinning-feedstock#3167
xref conda-forge/conda-forge.github.io#1810

CC @h-vetinari

#### Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
