### PR TITLE
Allow compiling with vs2022

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: rust_{{ cross_target_platform }}
@@ -40,7 +40,7 @@ outputs:
         - clang_{{ cross_target_platform }}    # [unix]
         # TODO: remove when clang_osx-64=17 is released
         - clang_impl_{{ target_platform }}     # [osx]
-        - vs2019_{{ cross_target_platform }}   # [win]
+        - vs_{{ cross_target_platform }} >=2019  # [win]
 {% endif %}
         - ld64_{{ target_platform }}  # [osx]
     test:


### PR DESCRIPTION
The background is the solving failure I see in https://github.com/conda-forge/librsvg-feedstock/pull/110 where `vs2022` is requested as a compiler. This would make the activation package more "open" but also would pull in `vs2022` probably as default?