### PR TITLE
fix: Update activation environment variables

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,7 +1,6 @@
-if not defined CARGO_HOME set CARGO_HOME=%CONDA_PREFIX%\.cargo
-if not defined CARGO_CONFIG set CARGO_CONFIG=%CARGO_HOME%\config
-if not defined RUSTUP_HOME set RUSTUP_HOME=%CARGO_HOME%\rustup
-set PATH=%CARGO_HOME%\bin;%PATH%
+if not defined CARGO_HOME set "CARGO_HOME=%CONDA_PREFIX%\.cargo"
+if not defined CARGO_CONFIG set "CARGO_CONFIG=%CARGO_HOME%\config"
+if not defined RUSTUP_HOME set "RUSTUP_HOME=%CARGO_HOME%\rustup"
 
 if not exist "%CARGO_HOME%" mkdir "%CARGO_HOME%"
 
@@ -10,6 +9,12 @@ set "CONDA_RUST_HOST=@rust_arch_env_build@"
 set "CONDA_RUST_TARGET=@rust_arch_env@"
 
 set "CARGO_TARGET_@rust_arch_env_build@_LINKER=link.exe"
+
+set "CARGO=%CONDA_PREFIX%\Library\bin\cargo"
+set "RUSTC=%CONDA_PREFIX%\Library\bin\rustc"
+set "RUSTDOC=%CONDA_PREFIX%\Library\bin\rustdoc"
+
+if not defined CARGO_INSTALL_ROOT set "CARGO_INSTALL_ROOT=%CONDA_PREFIX%\Library"
 
 if [%LD%] == [] (
     set "CARGO_TARGET_@rust_arch_env@_LINKER=link.exe"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-export CARGO_HOME=${CARGO_HOME:-${CONDA_PREFIX}/.cargo}
-export CARGO_CONFIG=${CARGO_CONFIG:-${CARGO_HOME}/config}
-export RUSTUP_HOME=${RUSTUP_HOME:-${CARGO_HOME}/rustup}
+export CARGO_HOME="${CARGO_HOME:-${CONDA_PREFIX}/.cargo}"
+export CARGO_CONFIG="${CARGO_CONFIG:-${CARGO_HOME}/config}"
+export RUSTUP_HOME="${RUSTUP_HOME:-${CARGO_HOME}/rustup}"
 
-[[ -d ${CARGO_HOME} ]] || mkdir -p ${CARGO_HOME}
+[[ -d "${CARGO_HOME}" ]] || mkdir -p "${CARGO_HOME}"
 
-export CARGO_TARGET_@rust_arch_env_build@_LINKER=${CC_FOR_BUILD:-${CONDA_PREFIX}/bin/@rust_default_cc_build@}
-export CARGO_TARGET_@rust_arch_env@_LINKER=${CC:-${CONDA_PREFIX}/bin/@rust_default_cc@}
-export CARGO_BUILD_TARGET=@rust_arch@
-export CONDA_RUST_HOST=@rust_arch_env_build@
-export CONDA_RUST_TARGET=@rust_arch_env@
-export PKG_CONFIG_PATH_@rust_arch_env_build@=${CONDA_PREFIX}/lib/pkgconfig
-export PKG_CONFIG_PATH_@rust_arch_env@=${PREFIX:-${CONDA_PREFIX}}/lib/pkgconfig
+export CARGO_TARGET_@rust_arch_env_build@_LINKER="${CC_FOR_BUILD:-${CONDA_PREFIX}/bin/@rust_default_cc_build@}"
+export CARGO_TARGET_@rust_arch_env@_LINKER="${CC:-${CONDA_PREFIX}/bin/@rust_default_cc@}"
+export CARGO_BUILD_TARGET="@rust_arch@"
+export CONDA_RUST_HOST="@rust_arch_env_build@"
+export CONDA_RUST_TARGET="@rust_arch_env@"
+export PKG_CONFIG_PATH_@rust_arch_env_build@="${CONDA_PREFIX}/lib/pkgconfig"
+export PKG_CONFIG_PATH_@rust_arch_env@="${PREFIX:-${CONDA_PREFIX}}/lib/pkgconfig"
 
 export CC_@CONDA_RUST_HOST_LOWER@="${CC_FOR_BUILD:-${CONDA_PREFIX}/bin/@rust_default_cc_build@}"
 export CFLAGS_@CONDA_RUST_HOST_LOWER@="-isystem ${CONDA_PREFIX}/include"
@@ -22,18 +22,25 @@ export CPPFLAGS_@CONDA_RUST_TARGET_LOWER@="${CPPFLAGS}"
 export CXXFLAGS_@CONDA_RUST_HOST_LOWER@="-isystem ${CONDA_PREFIX}/include"
 export CXXFLAGS_@CONDA_RUST_TARGET_LOWER@="${CXXFLAGS}"
 
+export CARGO="${CONDA_PREFIX}/bin/cargo"
+export RUSTC="${CONDA_PREFIX}/bin/rustc"
+export RUSTDOC="${CONDA_PREFIX}/bin/rustdoc"
+
+export CARGO_INSTALL_ROOT="${CARGO_INSTALL_ROOT:-${CONDA_PREFIX}}"
+
 if [[ "@cross_target_platform@" == linux*  ]]; then
   export CARGO_BUILD_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,${PREFIX:-${CONDA_PREFIX}}/lib -C link-arg=-Wl,-rpath,${PREFIX:-${CONDA_PREFIX}}/lib"
 elif [[ "@cross_target_platform@" == win* ]]; then
-  export CARGO_TARGET_@rust_arch_env@_LINKER=${CONDA_PREFIX}/bin/lld-link
+  export CARGO_INSTALL_ROOT="${CONDA_PREFIX}/Library"
+  export CARGO_TARGET_@rust_arch_env@_LINKER="${CONDA_PREFIX}/bin/lld-link"
 
   # some rust crates need a linux gnu c compiler at buildtime
   # thus we need to create custom cflags since the default ones are for clang
   export AR_@CONDA_RUST_HOST_LOWER@="${AR}"
-  export AR_@CONDA_RUST_TARGET_LOWER@=$CONDA_PREFIX/bin/llvm-lib
+  export AR_@CONDA_RUST_TARGET_LOWER@="$CONDA_PREFIX/bin/llvm-lib"
 
-  export CC_@CONDA_RUST_TARGET_LOWER@=$CONDA_PREFIX/bin/clang-cl
-  export CXX_@CONDA_RUST_TARGET_LOWER@=$CONDA_PREFIX/bin/clang-cl
+  export CC_@CONDA_RUST_TARGET_LOWER@="$CONDA_PREFIX/bin/clang-cl"
+  export CXX_@CONDA_RUST_TARGET_LOWER@="$CONDA_PREFIX/bin/clang-cl"
 
   export LDFLAGS="$LDFLAGS -manifest:no"
 
@@ -45,8 +52,6 @@ elif [[ "@cross_target_platform@" == osx* ]]; then
     export CARGO_BUILD_RUSTFLAGS="$CARGO_BUILD_RUSTFLAGS -C link-arg=-Wl,-headerpad_max_install_names -C link-arg=-Wl,-dead_strip_dylibs"
   fi
 fi
-
-export PATH=${CARGO_HOME}/bin:${PATH}
 
 # cross compiling for unix platforms
 if [[ "@cross_target_platform@" == osx* || "@cross_target_platform@" == linux* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: rust_{{ cross_target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,14 +61,15 @@ outputs:
         - rustdoc --help
         - cargo --help
         - cargo install --force xsv
-        - file $PREFIX/.cargo/bin/xsv  # [unix and cross_target_platform != "win-64" and cross_target_platform != "win-arm64"]
-        - file $PREFIX/.cargo/bin/xsv | grep "Mach-O 64-bit arm64 executable"  # [unix and cross_target_platform == "osx-arm64"]
-        - file $PREFIX/.cargo/bin/xsv | grep "Mach-O 64-bit x86_64 executable"  # [unix and cross_target_platform == "osx-64"]
-        - file $PREFIX/.cargo/bin/xsv | grep "ELF 64-bit LSB pie executable, x86-64"  # [unix and cross_target_platform == "linux-64"]
-        - file $PREFIX/.cargo/bin/xsv | grep "ELF 64-bit LSB pie executable, ARM aarch64"  # [unix and cross_target_platform == "linux-aarch64"]
-        - file $PREFIX/.cargo/bin/xsv | grep "ELF 64-bit LSB pie executable, 64-bit PowerPC"  # [unix and cross_target_platform == "linux-ppc64le"]
-        - file $PREFIX/.cargo/bin/xsv.exe  # [unix and cross_target_platform == "win-64"]
-        - file $PREFIX/.cargo/bin/xsv.exe  | grep "PE32+ executable for MS Windows" | grep x86-64  # [unix and cross_target_platform == "win-64"]
+        - file $PREFIX/bin/xsv  # [unix and not cross_target_platform.startswith("win")]
+        - file $PREFIX/bin/xsv | grep "Mach-O 64-bit arm64 executable"  # [unix and cross_target_platform == "osx-arm64"]
+        - file $PREFIX/bin/xsv | grep "Mach-O 64-bit x86_64 executable"  # [unix and cross_target_platform == "osx-64"]
+        - file $PREFIX/bin/xsv | grep "ELF 64-bit LSB pie executable, x86-64"  # [unix and cross_target_platform == "linux-64"]
+        - file $PREFIX/bin/xsv | grep "ELF 64-bit LSB pie executable, ARM aarch64"  # [unix and cross_target_platform == "linux-aarch64"]
+        - file $PREFIX/bin/xsv | grep "ELF 64-bit LSB pie executable, 64-bit PowerPC"  # [unix and cross_target_platform == "linux-ppc64le"]
+        - file $PREFIX/Library/bin/xsv.exe  # [unix and cross_target_platform == "win-64"]
+        - file $PREFIX/Library/bin/xsv.exe  | grep "PE32+ executable for MS Windows" | grep x86-64  # [unix and cross_target_platform == "win-64"]
+        - if not exist %PREFIX%\Library\bin\xsv.exe exit 1  # [win]
 
   - name: rust-gnu_{{ target_platform }}
     script: bld.bat


### PR DESCRIPTION
* Set CARGO, RUSTC and RUSTDOC to the respective binaries.
* Do not include $CARGO_HOME/bin into PATH. That is problematic when a user has rustup installed as the system binaries for cargo, rustc, etc. will always win over the conda-packaged ones.