### PR TITLE
Templatize activate.bat for cross-compilation

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -5,8 +5,14 @@ set PATH=%CARGO_HOME%\bin;%PATH%
 
 if not exist "%CARGO_HOME%" mkdir "%CARGO_HOME%"
 
+set "CARGO_BUILD_TARGET=@rust_arch@"
+set "CONDA_RUST_HOST=@rust_arch_env_build@"
+set "CONDA_RUST_TARGET=@rust_arch_env@"
+
+set "CARGO_TARGET_@rust_arch_env_build@_LINKER=link.exe"
+
 if [%LD%] == [] (
-    set "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=link.exe"
+    set "CARGO_TARGET_@rust_arch_env@_LINKER=link.exe"
 ) else (
-    set "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=%LD%"
+    set "CARGO_TARGET_@rust_arch_env@_LINKER=%LD%"
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,6 @@
 mkdir %PREFIX%\etc\conda\activate.d
-copy %RECIPE_DIR%\activate.bat %PREFIX%\etc\conda\activate.d\activate-%PKG_NAME%.bat
+copy %RECIPE_DIR%\activate.bat activate.bat
+
+powershell -NoProfile -Command "(Get-Content activate.bat -Raw) -replace '@rust_arch_env_build@', $env:rust_arch_env_build -replace '@rust_arch_env@', $env:rust_arch_env -replace '@rust_arch@', $env:rust_arch | Set-Content activate.bat -NoNewline"
+
+copy activate.bat %PREFIX%\etc\conda\activate.d\activate-%PKG_NAME%.bat


### PR DESCRIPTION
activate.bat hardcoded CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER, so cross-compiling to win-arm64 set the linker variable for the wrong arch. This PR tries to use the same behavior as the unix activation script for the variables that matter.